### PR TITLE
fix(either): fix monad comprehensions

### DIFF
--- a/spec/computations/either.spec.ts
+++ b/spec/computations/either.spec.ts
@@ -1,118 +1,135 @@
-import {either} from "../../src/computations/either";
-import {Either} from "../../src";
+import { Either } from "../../src";
+import { either } from "../../src/computations/either";
 
-describe('computations', function () {
+describe('computations', function() {
 
-    describe('either', function () {
+  describe('either', function() {
 
-        describe('eager', function () {
+    describe('eager', function() {
 
-            describe('The happy path, all bound functions return the right path.', function () {
+      describe('The happy path, all bound functions return the right path.', function() {
 
-                const getVeggies = () => Either.Right("carrots");
-                const getMeat = () => Either.Right("beyond beef");
-                const makeSoup = (veggies: string, meats: string) => Either.Right(`A delicious soup with ${veggies} and ${meats}`);
+        const getVeggies = () => Either.Right("carrots");
+        const getMeat = () => Either.Right("beyond beef");
+        const makeSoup = (veggies: string, meats: string) => Either.Right(`A delicious soup with ${veggies} and ${meats}`);
 
-                // noinspection DuplicatedCode
-                const getSoup = either.eager<Error, string>(({bind}) => {
-                    const veggies = bind(getVeggies());
-                    const meats = bind(getMeat());
-                    return bind(makeSoup(veggies, meats));
-                });
-
-                let result: Either<Error, string>;
-
-                beforeEach(function () {
-                    result = getSoup();
-                });
-
-                it("should return an Either", function () {
-                    expect(result).toBeInstanceOf(Either);
-                });
-
-                it('should return the right path', function () {
-                    expect(result.isRight()).toBe(true);
-                });
-
-                it('should contain the correct value', function () {
-                    expect(result.orNull()).toBe('A delicious soup with carrots and beyond beef');
-                });
-
-            });
-
-            describe('When one of the bound calls returns the left path', function () {
-
-                const MockError = new Error("The soup exploded into a billion tiny droplets!");
-
-                const getVeggies = () => Either.Right("carrots");
-                const getMeat = () => Either.Right("beyond beef");
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const makeSoup = (veggies: string, meats: string) => Either.Left(MockError);
-
-                // noinspection DuplicatedCode
-                const getSoup = either.eager<Error, string>(({bind}) => {
-                    const veggies = bind(getVeggies());
-                    const meats = bind(getMeat());
-                    return bind(makeSoup(veggies, meats));
-                });
-
-                let result: Either<Error, string>;
-
-                beforeEach(function () {
-                    result = getSoup();
-                });
-
-                it("should return an Either", function () {
-                    expect(result).toBeInstanceOf(Either);
-                });
-
-                it('should return the left path', function () {
-                    expect(result.isLeft()).toBe(true);
-                });
-
-                it('should contain the correct value', function () {
-                    expect(result.fold((l) => l, () => new Error("Wrong Error"))).toBe(MockError);
-                });
-
-            });
-
-            describe('When bound values have different types', function () {
-
-                const MockError = new Error("The soup exploded into a billion tiny droplets!");
-
-                const getVeggieType = () => Either.Right("bean");
-                const getVeggieCount = () => Either.Right(3);
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-                // noinspection DuplicatedCode
-                const getSoup = either.eager<Error, string>(({bind}) => {
-                    const veggieType = bind(getVeggieType());
-                    const veggieCount = bind(getVeggieCount());
-                    return `We have ${veggieCount} ${veggieType}s!`;
-                });
-
-                let result: Either<Error, string>;
-
-                beforeEach(function () {
-                    result = getSoup();
-                });
-
-                it("should return an Either", function () {
-                    expect(result).toBeInstanceOf(Either);
-                });
-
-                it('should return the right path', function () {
-                    expect(result.isRight()).toBe(true);
-                });
-
-                it('should contain the correct value', function () {
-                    expect(result.orNull()).toBe("We have 3 beans!");
-                });
-
-            });
-
+        // noinspection DuplicatedCode
+        const getSoup = either.eager<Error, string>(({ bind }) => {
+          const veggies = bind(getVeggies());
+          const meats = bind(getMeat());
+          return bind(makeSoup(veggies, meats));
         });
 
+        let result: Either<Error, string>;
+
+        beforeEach(function() {
+          result = getSoup();
+        });
+
+        it("should return an Either", function() {
+          expect(result).toBeInstanceOf(Either);
+        });
+
+        it('should return the right path', function() {
+          expect(result.isRight()).toBe(true);
+        });
+
+        it('should contain the correct value', function() {
+          expect(result.orNull()).toBe('A delicious soup with carrots and beyond beef');
+        });
+
+      });
+
+      describe('When one of the bound calls returns the left path', function() {
+
+        const MockError = new Error("The soup exploded into a billion tiny droplets!");
+
+        const getVeggies = () => Either.Right("carrots");
+        const getMeat = () => Either.Right("beyond beef");
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const makeSoup = (veggies: string, meats: string) => Either.Left(MockError);
+
+        // noinspection DuplicatedCode
+        const getSoup = either.eager<Error, string>(({ bind }) => {
+          const veggies = bind(getVeggies());
+          const meats = bind(getMeat());
+          return bind(makeSoup(veggies, meats));
+        });
+
+        let result: Either<Error, string>;
+
+        beforeEach(function() {
+          result = getSoup();
+        });
+
+        it("should return an Either", function() {
+          expect(result).toBeInstanceOf(Either);
+        });
+
+        it('should return the left path', function() {
+          expect(result.isLeft()).toBe(true);
+        });
+
+        it('should contain the correct value', function() {
+          expect(result.fold((l) => l, () => new Error("Wrong Error"))).toBe(MockError);
+        });
+
+      });
+
+      describe('When bound values have different types', function() {
+
+        const MockError = new Error("The soup exploded into a billion tiny droplets!");
+
+        const getVeggieType = () => Either.Right("bean");
+        const getVeggieCount = () => Either.Right(3);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+        // noinspection DuplicatedCode
+        const getSoup = either.eager<Error, string>(({ bind }) => {
+          const veggieType = bind(getVeggieType());
+          const veggieCount = bind(getVeggieCount());
+          return `We have ${veggieCount} ${veggieType}s!`;
+        });
+
+        let result: Either<Error, string>;
+
+        beforeEach(function() {
+          result = getSoup();
+        });
+
+        it("should return an Either", function() {
+          expect(result).toBeInstanceOf(Either);
+        });
+
+        it('should return the right path', function() {
+          expect(result.isRight()).toBe(true);
+        });
+
+        it('should contain the correct value', function() {
+          expect(result.orNull()).toBe("We have 3 beans!");
+        });
+
+      });
+
     });
+
+    describe('When an exception is thrown inside of a computation', function() {
+
+      const exception = 'Some internal exception'
+
+      const getCoolThing: () => Either<Error, String> = () => { throw exception }
+
+      const coolComputer = either.eager<Error, String>(({ bind }) => {
+        const cool = bind(getCoolThing())
+        return cool
+      })
+
+      it("should throw the nested non-computation exception", function() {
+        expect(coolComputer).toThrow(exception)
+      })
+
+    })
+
+  });
 
 });

--- a/src/computations/either.ts
+++ b/src/computations/either.ts
@@ -1,14 +1,19 @@
-import {Either} from "../Either";
-import {identity} from "../Identity";
+import { Either } from "../Either";
+import { identity } from "../Identity";
+
+
+function error(e: any): never {
+  throw e
+}
 
 class ComputeException<A> extends Error {
 
-    value: A;
+  value: A;
 
-    constructor(leftArg: A) {
-        super("");
-        this.value = leftArg;
-    }
+  constructor(leftArg: A) {
+    super("");
+    this.value = leftArg;
+  }
 
 }
 
@@ -17,18 +22,16 @@ class ComputeException<A> extends Error {
  */
 class ComputeContext<L> {
 
-    /**
-     * This will either resolve the passed in {@link Either} to the right side value, or thraw
-     * a {@link ComputeException} that will return control back to the parent {@link ComputeFunctions},
-     * resolving the left path of the passed in either argument.
-     *
-     * @param either - an {@link Either} that must have the same signature as its parent {@link ComputeFunctions}
-     */
-    bind<C>(either: Either<L, C>): C {
-        return either.fold(leftArg => {
-            throw new ComputeException(leftArg);
-        }, identity);
-    }
+  /**
+   * This will either resolve the passed in {@link Either} to the right side value, or thraw
+   * a {@link ComputeException} that will return control back to the parent {@link ComputeFunctions},
+   * resolving the left path of the passed in either argument.
+   *
+   * @param either - an {@link Either} that must have the same signature as its parent {@link ComputeFunctions}
+   */
+  bind<C>(either: Either<L, C>): C {
+    return either.fold(leftArg => error(new ComputeException(leftArg)), identity);
+  }
 
 }
 
@@ -36,17 +39,13 @@ type ComputeFunctions<L, R> = { (computeContext: ComputeContext<L>): R; };
 
 class either {
 
-    private static isComputeError<L>(candidate: any): candidate is ComputeException<L> {
-        return true
-    }
 
-    static eager<L, R>(computeFunctions: ComputeFunctions<L, R>): () => Either<L, R> {
-        return () => Either
-            .catch(() => computeFunctions(new ComputeContext<L>()))
-            .mapLeft((candidate: L): L => {
-                if (either.isComputeError(candidate)) return candidate.value as L; else throw candidate
-            })
-    }
+  static eager<L, R>(computeFunctions: ComputeFunctions<L, R>): () => Either<L, R> {
+    return () => Either
+      .catch(() => computeFunctions(new ComputeContext<L>()))
+      .mapLeft((candidate: L): L => candidate instanceof ComputeException ? candidate.value as L : error(candidate))
+
+  }
 
 }
 


### PR DESCRIPTION
```
this fixes an issue where unhandled exceptions in monad comprehensions were not discriminated from 
ComputationExceptions leading to unexpected left values that did not match their signature.
```

Fixes N/A